### PR TITLE
MS-8283 Removing sustanceName that was making kmehr invalid for Compound Prescriptions

### DIFF
--- a/src/main/kotlin/org/taktik/connector/business/recipe/utils/KmehrPrescriptionHelperV4.kt
+++ b/src/main/kotlin/org/taktik/connector/business/recipe/utils/KmehrPrescriptionHelperV4.kt
@@ -345,7 +345,6 @@ object KmehrPrescriptionHelperV4 {
                             })
                             compound.substanceProduct?.let { (substanceCode, name) ->
                                 substance = SubstanceType().apply {
-                                    substancename = name
                                     substanceCode?.let {
                                         cd = CDSUBSTANCE().apply {
                                             s = CDSUBSTANCEschemes.fromValue(substanceCode.type)


### PR DESCRIPTION
The Kmehr was invalid because of the sustanceName entry for Compound prescriptions. The name is already included in the "cd" under the "dn" tag.