### PR TITLE
Fix related code flatfile write in record 51 for dentist

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/BelgianInsuranceInvoicingFormatWriter.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/BelgianInsuranceInvoicingFormatWriter.kt
@@ -483,8 +483,10 @@ class BelgianInsuranceInvoicingFormatWriter(private val writer: Writer) {
         ws.write("5", FuzzyValues.getLocalDateTime(icd.dateCode!!)!!.format(dtf))
         ws.write("8a", noSIS)
         ws.write("15", icd.doctorIdentificationNumber)
-        if (isDentist) {
-            ws.write("17", icd.relatedCode ?: 0)
+        if (isDentist && icd.relatedCode !== null) {
+            val relatedCode = icd.relatedCode.toString();
+            ws.write("17", relatedCode.take(3))
+            ws.write("18", relatedCode.takeLast(3))
         }
         else {
             ws.write("17", 0)


### PR DESCRIPTION
The purpose of this PR is to correct an inconsistency when writing flat files for dentists. Instead of writing the relative service only in field 17, we split it between fields 17 and 18 in record 51 as specified in the [documentation](https://www.inami.fgov.be/fr/professionnels/info-pour-tous/facturer-electroniquement
).

![image](https://github.com/icure/freehealth-connector/assets/121036715/bf2fb390-59dd-4d6b-98e4-9f26e98545f5)
<img width="742" alt="image" src="https://github.com/icure/freehealth-connector/assets/121036715/a93de627-9a6b-4aa1-949f-5d279ab3f012">
