### PR TITLE
Handle more than one related service in tarif endpoint

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/TarificationService.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/TarificationService.kt
@@ -23,6 +23,6 @@ interface TarificationService {
                      guardPostNihii: String?,
                      guardPostSsin: String?,
                      anatomy: String?,
-                     relatedService: String?,
+                     relatedServices: List<String?>,
                      codes: List<String>): TarificationConsultationResult
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/TarificationService.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/TarificationService.kt
@@ -22,7 +22,7 @@ interface TarificationService {
                      traineeSupervisorLastName: String?,
                      guardPostNihii: String?,
                      guardPostSsin: String?,
-                     anatomy: String?,
+                     anatomies: List<String?>,
                      relatedServices: List<String?>,
                      codes: List<String>): TarificationConsultationResult
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/TarificationServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/TarificationServiceImpl.kt
@@ -76,7 +76,7 @@ class TarificationServiceImpl(private val stsService: STSService) : Tarification
                               guardPostNihii: String?,
                               guardPostSsin: String?,
                               anatomy: String?,
-                              relatedService: String?,
+                              relatedServices: List<String?>,
                               codes: List<String>): TarificationConsultationResult {
         val samlToken =
             stsService.getSAMLToken(tokenId, keystoreId, passPhrase)
@@ -151,7 +151,7 @@ class TarificationServiceImpl(private val stsService: STSService) : Tarification
                             cds.add(CDITEM().apply { s = CDITEMschemes.CD_ITEM; sv = "1.0"; value = "encounterdatetime" })
                             contents.add(ContentType().apply { date = csDT })
                         })
-                        headingsAndItemsAndTexts.addAll(codes.map { code ->
+                        headingsAndItemsAndTexts.addAll(codes.mapIndexed { index, code ->
                             ItemType().apply {
                                 ids.add(IDKMEHR().apply { s = IDKMEHRschemes.ID_KMEHR; sv = "1.0"; value = (h++).toString() })
                                 cds.add(CDITEM().apply { s = CDITEMschemes.CD_ITEM; sv = "1.0"; value = "claim" })
@@ -164,7 +164,8 @@ class TarificationServiceImpl(private val stsService: STSService) : Tarification
                                             cds.add(CDCONTENT().apply { s = CDCONTENTschemes.CD_ISO_3950; sv = "1.0"; value = anatomy })
                                         })
                                     }
-                                    if (relatedService != null) {
+                                    val relatedService = relatedServices[index]
+                                    if (!relatedService.isNullOrEmpty()) {
                                         contents.add(ContentType().apply {
                                             cds.add(CDCONTENT().apply { s = CDCONTENTschemes.CD_NIHDI_RELATEDSERVICE; sv = "1.0"; value = relatedService })
                                         })

--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/TarificationServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/TarificationServiceImpl.kt
@@ -160,7 +160,7 @@ class TarificationServiceImpl(private val stsService: STSService) : Tarification
                                 })
                                 if (isDentist) {
                                     val anatomy = anatomies[index]
-                                    if (anatomy != null) {
+                                    if (!anatomy.isNullOrEmpty()) {
                                         contents.add(ContentType().apply {
                                             cds.add(CDCONTENT().apply { s = CDCONTENTschemes.CD_ISO_3950; sv = "1.0"; value = anatomy })
                                         })

--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/TarificationServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/TarificationServiceImpl.kt
@@ -75,7 +75,7 @@ class TarificationServiceImpl(private val stsService: STSService) : Tarification
                               traineeSupervisorLastName: String?,
                               guardPostNihii: String?,
                               guardPostSsin: String?,
-                              anatomy: String?,
+                              anatomies: List<String?>,
                               relatedServices: List<String?>,
                               codes: List<String>): TarificationConsultationResult {
         val samlToken =
@@ -159,6 +159,7 @@ class TarificationServiceImpl(private val stsService: STSService) : Tarification
                                     cds.add(CDCONTENT().apply { s = CDCONTENTschemes.CD_NIHDI; sv = "1.0"; value = code })
                                 })
                                 if (isDentist) {
+                                    val anatomy = anatomies[index]
                                     if (anatomy != null) {
                                         contents.add(ContentType().apply {
                                             cds.add(CDCONTENT().apply { s = CDCONTENTschemes.CD_ISO_3950; sv = "1.0"; value = anatomy })

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/TarificationController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/TarificationController.kt
@@ -89,12 +89,12 @@ class TarificationController(val tarificationService: TarificationService, val m
         traineeSupervisorLastName = traineeSupervisorLastName,
         guardPostNihii = guardPostNihii,
         guardPostSsin = guardPostSsin,
-        anatomies = anatomy?.split(',').also {
-            if (it?.isNotEmpty() == true && it.size != codes.size) throw IllegalArgumentException("Anatomy length must match codes length.")
-        } ?: codes.map { null },
-        relatedServices = relatedService?.split(',').also {
-            if (it?.isNotEmpty() == true && it.size != codes.size) throw IllegalArgumentException("Related services length must match codes length.")
-        } ?: codes.map { null }).let { mapper.map(it, TarificationConsultationResult::class.java) } }
+        anatomies = if (anatomy?.contains(',') == true) anatomy.split(',').also {
+            if (it.size != codes.size) throw IllegalArgumentException("Anatomy length must match codes length.")
+        } else codes.map { anatomy },
+        relatedServices = if (relatedService?.contains(',') == true) relatedService.split(',').also {
+            if (it.size != codes.size) throw IllegalArgumentException("Related services length must match codes length.")
+        } else codes.map { relatedService }).let { mapper.map(it, TarificationConsultationResult::class.java) } }
     catch (e: javax.xml.ws.soap.SOAPFaultException) {
          TarificationConsultationResult().apply {
              errors = extractError(e).toMutableList()

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/TarificationController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/TarificationController.kt
@@ -67,9 +67,10 @@ class TarificationController(val tarificationService: TarificationService, val m
         @RequestParam(required = false) guardPostNihii: String?,
         @RequestParam(required = false) guardPostSsin: String?,
         @RequestParam(required = false) anatomy: String?,
-        @RequestParam(required = false) relatedServices: List<String?>,
+        @RequestParam(required = false) relatedService: String?,
         @RequestBody codes: List<String>
-    ) = try { tarificationService.consultTarif(
+    ) = try {
+        tarificationService.consultTarif(
         keystoreId = keystoreId,
         tokenId = tokenId,
         hcpFirstName = hcpFirstName,
@@ -88,8 +89,12 @@ class TarificationController(val tarificationService: TarificationService, val m
         traineeSupervisorLastName = traineeSupervisorLastName,
         guardPostNihii = guardPostNihii,
         guardPostSsin = guardPostSsin,
-        anatomy = anatomy,
-        relatedServices =  relatedServices).let { mapper.map(it, TarificationConsultationResult::class.java) } }
+        anatomies = anatomy?.split(',').also {
+            if (it?.isNotEmpty() == true && it.size != codes.size) throw IllegalArgumentException("Anatomy length must match codes length.")
+        } ?: codes.map { null },
+        relatedServices = relatedService?.split(',').also {
+            if (it?.isNotEmpty() == true && it.size != codes.size) throw IllegalArgumentException("Related services length must match codes length.")
+        } ?: codes.map { null }).let { mapper.map(it, TarificationConsultationResult::class.java) } }
     catch (e: javax.xml.ws.soap.SOAPFaultException) {
          TarificationConsultationResult().apply {
              errors = extractError(e).toMutableList()

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/TarificationController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/TarificationController.kt
@@ -67,7 +67,7 @@ class TarificationController(val tarificationService: TarificationService, val m
         @RequestParam(required = false) guardPostNihii: String?,
         @RequestParam(required = false) guardPostSsin: String?,
         @RequestParam(required = false) anatomy: String?,
-        @RequestParam(required = false) relatedService: String?,
+        @RequestParam(required = false) relatedServices: List<String?>,
         @RequestBody codes: List<String>
     ) = try { tarificationService.consultTarif(
         keystoreId = keystoreId,
@@ -89,7 +89,7 @@ class TarificationController(val tarificationService: TarificationService, val m
         guardPostNihii = guardPostNihii,
         guardPostSsin = guardPostSsin,
         anatomy = anatomy,
-        relatedService =  relatedService).let { mapper.map(it, TarificationConsultationResult::class.java) } }
+        relatedServices =  relatedServices).let { mapper.map(it, TarificationConsultationResult::class.java) } }
     catch (e: javax.xml.ws.soap.SOAPFaultException) {
          TarificationConsultationResult().apply {
              errors = extractError(e).toMutableList()


### PR DESCRIPTION
The current "/tarif" endpoint only supports a single relatedService. This correction allows an array of strings to be managed instead of a single string. This only creates a breaking change for people relying on the current optional "relatedService" parameter (which doesn't work). A better approach would be to provide a CodeAndRelatedServiceDto array in the body of the request, so that each code could provide its optional related service code. But this would involve further breaking changes. 