### PR TITLE
Default value of justification set to 0

### DIFF
--- a/src/main/java/org/taktik/connector/business/domain/etarif/TarificationConsultationResult.java
+++ b/src/main/java/org/taktik/connector/business/domain/etarif/TarificationConsultationResult.java
@@ -280,7 +280,7 @@ public class TarificationConsultationResult implements Serializable {
 		private Payment reimbursement;
 		private Payment patientFee;
 		private String contract;
-		private String justification;
+		private String justification = "O";
 
 		public String getCode() {
 			return code;


### PR DESCRIPTION
Set default justification to "0" instead of null because the serializable object only accepts "0"