### PR TITLE
Invoicing percent norm in Efac send batch: Handle pseudocode for dental prothesis

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/dto/efact/InvoicingPercentNorm.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/dto/efact/InvoicingPercentNorm.kt
@@ -33,7 +33,8 @@ enum class InvoicingPercentNorm private constructor(val code: Int) {
     Ah1n1(4),
     HalfPriceSecondAct(5),
     InvoiceException(6),
-    ForInformation(7);
+    ForInformation(7),
+    PseudoCodeProthesis(9);
 
 
     companion object {


### PR DESCRIPTION
The goal of this PR is to handle the case where a dentist needs to bill dental prothesis. In order to do it, several pseudo code should be added before the sending to Efac. These pseudocode should have the value 9 inside the Invoicing percent norm ( record 50 zone 3). The value 9 is handled yet by the FHC and therefore a small modification should be done. You can find below the official documentation from the Inami which explains this particular case.
<img width="724" alt="Capture d’écran 2024-07-22 à 14 36 49" src="https://github.com/user-attachments/assets/66ba67b3-777c-496b-a157-bad19ec3f205">

