### PR TITLE
eHealth connection for logopedist, dietician, clinical psychologist and optician

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/MemberDataServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/MemberDataServiceImpl.kt
@@ -781,6 +781,7 @@ class MemberDataServiceImpl(val stsService: STSService, keyDepotService: KeyDepo
                 hcpQuality == "optician" ||
                 hcpQuality == "podologist" ||
                 hcpQuality == "dietician" ||
+                hcpQuality == "clinicalpsychologist" ||
                 hcpQuality == "hospital" ||
                 hcpQuality == "groupofnurses" ||
                 hcpQuality == "labo" ||

--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/STSServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/STSServiceImpl.kt
@@ -362,6 +362,87 @@ class STSServiceImpl(val keystoresMap: IMap<UUID, ByteArray>, val tokensMap: IMa
                 "urn:be:fgov:certified-namespace:ehealth"
                 )
             )
+            "logopedist" -> listOf(
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:ehealth:1.0:certificateholder:person:ssin",
+                    "urn:be:fgov:identification-namespace"
+                ),
+                SAMLAttributeDesignator("urn:be:fgov:person:ssin", "urn:be:fgov:identification-namespace"),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:professional:logopedist:boolean",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:nihii:logopedist:nihii11",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:givenname",
+                "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:surname",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:fpsph:logopedist:boolean",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                )
+            )
+            "dietician" -> listOf(
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:ehealth:1.0:certificateholder:person:ssin",
+                    "urn:be:fgov:identification-namespace"
+                ),
+                SAMLAttributeDesignator("urn:be:fgov:person:ssin", "urn:be:fgov:identification-namespace"),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:professional:dietician:boolean",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:nihii:dietician:nihii11",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:givenname",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:surname",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:fpsph:dietician:boolean",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                )
+            )
+            "clinicalpsychologist" -> listOf(
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:ehealth:1.0:certificateholder:person:ssin",
+                    "urn:be:fgov:identification-namespace"
+                ),
+                SAMLAttributeDesignator("urn:be:fgov:person:ssin", "urn:be:fgov:identification-namespace"),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:professional:clinicalpsychologist:boolean",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:nihii:clinicalpsychologist:nihii11",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:givenname",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:surname",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:fpsph:clinicalpsychologist:boolean",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                )
+            )
             "midwife" -> listOf(
                 SAMLAttributeDesignator(
                     "urn:be:fgov:ehealth:1.0:certificateholder:person:ssin",


### PR DESCRIPTION
The initial requirement was to be able to use member data with the logopedist, dietician, clinical psychologist and optician. This meant adding support for eHealth connection for the missing professions, as well as support for the clinical psychologist in member data.

It seems to work fine, but for the optician I kept getting the error:

`<soapenv:Fault xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><faultcode xmlns:wst="http://docs.oasis-open.org/ws-sx/ws-trust/200512">wst:InvalidRequest</faultcode><faultstring>The request was invalid or malformed</faultstring><detail><urn:BusinessError xmlns:urn="urn:be:fgov:ehealth:errors:soa:v1" Id="..."><Origin>Client</Origin><Code>urn:oasis:names:tc:SAML:2.0:status:RequestDenied</Code><Message xml:lang="en">Message did not meet security requirements</Message><Message xml:lang="en">Requester CN="SSIN=...", OU=eHealth-platform Belgium, OU=..., OU="SSIN=...", O=Federal Government, C=BE is not allowed to request attribute urn:be:fgov:person:ssin:ehealth:1.0:fpsph:optician:boolean</Message><urn:Environment>Acceptation</urn:Environment></urn:BusinessError></detail></soapenv:Fault>`

with similar attributes as for other professions:

```
SAMLAttributeDesignator(
    "urn:be:fgov:ehealth:1.0:certificateholder:person:ssin",
    "urn:be:fgov:identification-namespace"
),
SAMLAttributeDesignator("urn:be:fgov:person:ssin", "urn:be:fgov:identification-namespace"),
SAMLAttributeDesignator(
    "urn:be:fgov:person:ssin:ehealth:1.0:professional:optician:boolean",
    "urn:be:fgov:certified-namespace:ehealth"
),
SAMLAttributeDesignator(
    "urn:be:fgov:person:ssin:ehealth:1.0:nihii:optician:nihii11",
    "urn:be:fgov:certified-namespace:ehealth"
),
SAMLAttributeDesignator(
    "urn:be:fgov:person:ssin:ehealth:1.0:givenname",
    "urn:be:fgov:certified-namespace:ehealth"
),
SAMLAttributeDesignator(
    "urn:be:fgov:person:ssin:ehealth:1.0:surname",
    "urn:be:fgov:certified-namespace:ehealth"
),
SAMLAttributeDesignator(
    "urn:be:fgov:person:ssin:ehealth:1.0:fpsph:optician:boolean",
    "urn:be:fgov:certified-namespace:ehealth"
)
```

I'm not sure I'm defining the right attributes, as I haven't found the relevant eHealth documentation. Do you have any thoughts?

In addition, during my tests, I used the same username authentication property as for doctors. I'm not sure if this is a problem?