### PR TITLE
eHealth connection for optician

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/STSServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/STSServiceImpl.kt
@@ -443,6 +443,25 @@ class STSServiceImpl(val keystoresMap: IMap<UUID, ByteArray>, val tokensMap: IMa
                     "urn:be:fgov:certified-namespace:ehealth"
                 )
             )
+            "optician" -> listOf(
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:ehealth:1.0:certificateholder:person:ssin",
+                    "urn:be:fgov:identification-namespace"
+                ),
+                SAMLAttributeDesignator("urn:be:fgov:person:ssin", "urn:be:fgov:identification-namespace"),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:nihii:optician:nihii11",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:givenname",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                ),
+                SAMLAttributeDesignator(
+                    "urn:be:fgov:person:ssin:ehealth:1.0:surname",
+                    "urn:be:fgov:certified-namespace:ehealth"
+                )
+            )
             "midwife" -> listOf(
                 SAMLAttributeDesignator(
                     "urn:be:fgov:ehealth:1.0:certificateholder:person:ssin",


### PR DESCRIPTION
Following the comments made at https://github.com/icure/freehealth-connector/pull/51, I have deleted the following:

```
SAMLAttributeDesignator(
    "urn:be:fgov:person:ssin:ehealth:1.0:professional:optician:boolean",
    "urn:be:fgov:certified-namespace:ehealth"
),
SAMLAttributeDesignator(
    "urn:be:fgov:person:ssin:ehealth:1.0:fpsph:optician:boolean",
    "urn:be:fgov:certified-namespace:ehealth"
)
```

And it seems to be working fine.