### PR TITLE
Feature/eagreement v2

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
@@ -1,5 +1,6 @@
 package org.taktik.freehealth.middleware.web
 
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -39,4 +40,9 @@ class ExceptionHandlers {
     @ExceptionHandler(Exception::class)
     fun handleException(request: HttpServletRequest, exception: Exception) =
             ExceptionDto(HttpStatus.INTERNAL_SERVER_ERROR, exception, request.servletPath).toResponseEntity()
+                .also { log.error("Unhandled exception on ${request.servletPath}", exception) }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(ExceptionHandlers::class.java)
+    }
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
@@ -4,12 +4,15 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.taktik.connector.technical.exception.SoaErrorException
 import org.taktik.connector.technical.exception.TechnicalConnectorException
-import org.taktik.freehealth.middleware.dto.ExceptionDto
 import org.taktik.freehealth.middleware.exception.MissingKeystoreException
 import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.exception.UnauthorizedException
+import be.fgov.ehealth.commons.protocol.v2.StatusResponseType
+import org.taktik.freehealth.middleware.dto.ExceptionDto
 import java.io.EOFException
+import java.util.Date
 import javax.servlet.http.HttpServletRequest
 import javax.xml.ws.soap.SOAPFaultException
 
@@ -21,6 +24,21 @@ class ExceptionHandlers {
     @ExceptionHandler(TechnicalConnectorException::class)
     fun handleTechnicalConnectorException(request: HttpServletRequest, exception: TechnicalConnectorException) =
             ExceptionDto(exception.category.httpStatus, exception, request.servletPath).toResponseEntity()
+
+    /**
+     * SoaErrorException only carries the eHealth status code in its message, while the reason why the platform
+     * refused the call sits in the response's statusMessage ("This combination of search criteria is not supported.",
+     * "The maxElements paging attribute is too high.", …). Append it so callers get something actionable.
+     */
+    @ExceptionHandler(SoaErrorException::class)
+    fun handleSoaErrorException(request: HttpServletRequest, exception: SoaErrorException) =
+            ExceptionDto(
+                Date(),
+                exception.category.httpStatus.value(),
+                exception.category.httpStatus.reasonPhrase,
+                listOfNotNull(exception.message, statusMessageOf(exception)).joinToString(" - "),
+                request.servletPath
+            ).toResponseEntity()
 
     @ExceptionHandler(MissingKeystoreException::class, MissingTokenException::class, UnauthorizedException::class)
     fun handleUnauthorizedException(request: HttpServletRequest, exception: Exception) =
@@ -41,6 +59,14 @@ class ExceptionHandlers {
     fun handleException(request: HttpServletRequest, exception: Exception) =
             ExceptionDto(HttpStatus.INTERNAL_SERVER_ERROR, exception, request.servletPath).toResponseEntity()
                 .also { log.error("Unhandled exception on ${request.servletPath}", exception) }
+
+    private fun statusMessageOf(exception: SoaErrorException): String? = try {
+        (exception.responseTypeV2 as? StatusResponseType)?.status?.statusMessage
+            ?: exception.responseType?.status?.messages?.firstOrNull()?.value
+            ?: exception.errorType?.messages?.firstOrNull()?.value
+    } catch (e: Exception) {
+        null
+    }
 
     companion object {
         private val log = LoggerFactory.getLogger(ExceptionHandlers::class.java)


### PR DESCRIPTION
## eAgreement: add the v2 protocol binding

`AgreementServiceImpl` hard-codes the v1 SOAP actions
(`urn:be:fgov:ehealth:mycarenet:agreement:protocol:v1:{Ask,Consult}Agreement`) and `endpoint.agreement`
points at `.../MyCareNet/eAgreement/v1`, while the payload builder is already FHIR-based
(`Bundle`, `Claim`, `agreement-types`, `nihdi-physiotherapy-pathologysituationcode`) — v2 vocabulary.
The CIN test procedures now target v2.

This adds the v2 binding. Measured against the acceptance platform with a physiotherapist certificate:

| binding sent | endpoint | answer |
|---|---|---|
| v1 SOAP action | `/eAgreement/v1` | `SOA-01002` not authorized |
| v1 SOAP action | `/eAgreement/v2` | `SOA-03004` WS-I compliance failure |
| **v2 SOAP action** | `/eAgreement/v2` | accepted — `askAgreement` completes end to end |

`askAgreement` returns HTTP 200, `acknowledged: true`, a NIP reference in `commonOutput`, and a signed FHIR
`be-eagreementdemandreply` from the insurer. (`consultAgreement` still answers `SOA-01002` on our licence —
authorisation is granted per operation by the CIN, not a code issue.)

### What the commits do

1. **`feat(eagreement): add v2 protocol JAXB wrappers`** — the five wrappers from
   `mycarenet-agreement-protocol-2_0.xsd`, under the official package
   `be.fgov.ehealth.mycarenet.agreement.protocol.v2` (v1 lives under `be.fgov.ehealth.agreement.protocol.v1`,
   without `mycarenet`). They are 11-line classes extending `SendRequestType`/`SendResponseType`.
2. **`feat(eagreement): add v2 service binding and endpoint.agreement2`** — new
   `org.taktik.connector.business.agreementv2` package (service, `ServiceFactory`, impl) carrying the `:v2:`
   SOAP actions, keyed on a new `endpoint.agreement2` property declared for acpt and prod.
   **The v1 package is left untouched.**
3. **`feat(eagreement): route the service to v2`** — `EagreementServiceImpl` targets the v2 binding; the
   payload types move from `commons.protocol.v3` to `v4` (already present in this repo, eAttest v3 uses them),
   so `RoutingType.referenceDate` becomes an `XMLGregorianCalendar`. Also adds the missing Swagger
   `@ApiOperation` descriptions.
4. **`fix(mycarenet): send the v4 Detail MessageVersion attribute`** — `BlobType` gained a `MessageVersion`
   attribute in mycarenet commons v4, but the **v4 `BlobMapper` never copied it**, so the Detail element went
   out without it and the service answered `INVALID_DETAIL_REQUEST: messageVersion invalid (mandatory)`.
   This is a generic v4 bug, not specific to eAgreement; the official connector fixed the same omission for
   eAttest v3 in 4.3.0-beta-3. eAgreement sets it to `V4`, the value the CIN message definition mandates.
5. **`fix(eagreement): repair the async origin block`** — `/eagreement/async/*` read the package name from
   `genericasync.dmg.package.name` (the DMG key) instead of `genericasync.eagreement.package.name`, and took
   the licence from the authenticated principal only, throwing `No MCN license found` when there was none,
   while every other flow falls back to the configured licence. The `genericasync.eagreement.package.license.*`
   keys already exist in the tracked properties files. `getMessages` now returns 200 from the GenAsync channel.

### One decision for you

Commit 3 **switches every caller from v1 to v2**, it is not opt-in. That seemed right since v1 answers
`SOA-01002` for us, but you may have users still on v1 — happy to gate the binding behind a config flag
(e.g. keeping `endpoint.agreement` for v1 and selecting on a property) if you prefer. Say the word and I'll
rework it.

### Not included

The async decision channel (the medical adviser's ruling arriving over GenAsync, which the official packaging
ships as a separate `business-mycareneteagreementasyncv2` module) is not part of this PR.

Built and compiled against JDK 8 / Gradle 6.7. Not covered by automated tests — the eAgreement path needs a
live certificate; the results above are manual runs against acceptance.
