### PR TITLE
feat(addressbook): search professionals on any criteria combination

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
@@ -1,5 +1,6 @@
 package org.taktik.freehealth.middleware.web
 
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -39,4 +40,9 @@ class ExceptionHandlers {
     @ExceptionHandler(Exception::class)
     fun handleException(request: HttpServletRequest, exception: Exception) =
             ExceptionDto(HttpStatus.INTERNAL_SERVER_ERROR, exception, request.servletPath).toResponseEntity()
+                .also { log.error("Unhandled exception on ${request.servletPath}", exception) }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(ExceptionHandlers::class.java)
+    }
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
@@ -4,12 +4,15 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.taktik.connector.technical.exception.SoaErrorException
 import org.taktik.connector.technical.exception.TechnicalConnectorException
-import org.taktik.freehealth.middleware.dto.ExceptionDto
 import org.taktik.freehealth.middleware.exception.MissingKeystoreException
 import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.exception.UnauthorizedException
+import be.fgov.ehealth.commons.protocol.v2.StatusResponseType
+import org.taktik.freehealth.middleware.dto.ExceptionDto
 import java.io.EOFException
+import java.util.Date
 import javax.servlet.http.HttpServletRequest
 import javax.xml.ws.soap.SOAPFaultException
 
@@ -21,6 +24,21 @@ class ExceptionHandlers {
     @ExceptionHandler(TechnicalConnectorException::class)
     fun handleTechnicalConnectorException(request: HttpServletRequest, exception: TechnicalConnectorException) =
             ExceptionDto(exception.category.httpStatus, exception, request.servletPath).toResponseEntity()
+
+    /**
+     * SoaErrorException only carries the eHealth status code in its message, while the reason why the platform
+     * refused the call sits in the response's statusMessage ("This combination of search criteria is not supported.",
+     * "The maxElements paging attribute is too high.", …). Append it so callers get something actionable.
+     */
+    @ExceptionHandler(SoaErrorException::class)
+    fun handleSoaErrorException(request: HttpServletRequest, exception: SoaErrorException) =
+            ExceptionDto(
+                Date(),
+                exception.category.httpStatus.value(),
+                exception.category.httpStatus.reasonPhrase,
+                listOfNotNull(exception.message, statusMessageOf(exception)).joinToString(" - "),
+                request.servletPath
+            ).toResponseEntity()
 
     @ExceptionHandler(MissingKeystoreException::class, MissingTokenException::class, UnauthorizedException::class)
     fun handleUnauthorizedException(request: HttpServletRequest, exception: Exception) =
@@ -41,6 +59,14 @@ class ExceptionHandlers {
     fun handleException(request: HttpServletRequest, exception: Exception) =
             ExceptionDto(HttpStatus.INTERNAL_SERVER_ERROR, exception, request.servletPath).toResponseEntity()
                 .also { log.error("Unhandled exception on ${request.servletPath}", exception) }
+
+    private fun statusMessageOf(exception: SoaErrorException): String? = try {
+        (exception.responseTypeV2 as? StatusResponseType)?.status?.statusMessage
+            ?: exception.responseType?.status?.messages?.firstOrNull()?.value
+            ?: exception.errorType?.messages?.firstOrNull()?.value
+    } catch (e: Exception) {
+        null
+    }
 
     companion object {
         private val log = LoggerFactory.getLogger(ExceptionHandlers::class.java)


### PR DESCRIPTION
## Addressbook: search professionals on any criteria combination

`GET /ab/search/hcp/{lastName}` only searches on a last name and silently defaults the profession to
`PHYSICIAN`, so there is no way to reach the other search combinations the eHealth `SearchProfessionals`
operation supports.

This adds `GET /ab/search/hcp`, where every criterion is an optional query parameter: `lastName`, `firstName`,
`profession`, `nihii`, `ssin`, `zipCode`, `city`, `email`, `offset`, `limit`. The existing path-variable route
is left untouched.

Validation is done before any eHealth call, so the offline test can cover it:

- the XSD declares `NIHII|SSIN` and `City|ZipCode` as `xs:choice`, so each pair is mutually exclusive (400);
- an empty query is rejected;
- `maxElements` is capped at 100 by the service (`The maxElements paging attribute is too high.`);
- omitting `profession` (or passing `ALL`) leaves the element out rather than defaulting to `PHYSICIAN`.

Beyond that the eHealth service decides. Measured on acceptance with a physiotherapist token — a refusal comes
back as `Requester - This combination of search criteria is not supported.` The rule turns out to be
*profession plus either a name or a location, or else an identifier on its own*:

| criteria | result |
|---|---|
| `lastName` (+ `firstName`) + `profession` | OK |
| `profession` + `zipCode` or + `city` | OK |
| `nihii` alone, `ssin` alone | OK |
| `profession` alone | refused |
| `lastName` alone, `zipCode` alone (no profession) | refused |
| name **and** location together | refused |
| `firstName` without `lastName` | refused |
| `email` | refused |

So "search by name anywhere" and "search by zip code across professions" both need one call per profession.
Names accept a `*` wildcard (`Steeman*`). The protocol returns no total, so callers page with `offset` until a
page holds fewer than `limit` rows.

Note the search response carries identity, `nihii`, `professionCodes` and `speciality` only — no address and no
eHealthBox, because `SearchProfessionalsResponse` returns `aa:HealthCareProfessional`, which has no address.
Those are resolved with `GET /ab/hcp/nihii/{nihii}` once a result is picked.

Includes `AddressbookControllerOfflineTest`, which boots the app and exercises the criteria validation and
`/v2/api-docs` with fake auth headers — no keystore and no network needed (~30 s).
