### PR TITLE
Fix/exception handlers

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
@@ -1,5 +1,6 @@
 package org.taktik.freehealth.middleware.web
 
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -39,4 +40,9 @@ class ExceptionHandlers {
     @ExceptionHandler(Exception::class)
     fun handleException(request: HttpServletRequest, exception: Exception) =
             ExceptionDto(HttpStatus.INTERNAL_SERVER_ERROR, exception, request.servletPath).toResponseEntity()
+                .also { log.error("Unhandled exception on ${request.servletPath}", exception) }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(ExceptionHandlers::class.java)
+    }
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
@@ -4,12 +4,15 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.taktik.connector.technical.exception.SoaErrorException
 import org.taktik.connector.technical.exception.TechnicalConnectorException
-import org.taktik.freehealth.middleware.dto.ExceptionDto
 import org.taktik.freehealth.middleware.exception.MissingKeystoreException
 import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.exception.UnauthorizedException
+import be.fgov.ehealth.commons.protocol.v2.StatusResponseType
+import org.taktik.freehealth.middleware.dto.ExceptionDto
 import java.io.EOFException
+import java.util.Date
 import javax.servlet.http.HttpServletRequest
 import javax.xml.ws.soap.SOAPFaultException
 
@@ -21,6 +24,21 @@ class ExceptionHandlers {
     @ExceptionHandler(TechnicalConnectorException::class)
     fun handleTechnicalConnectorException(request: HttpServletRequest, exception: TechnicalConnectorException) =
             ExceptionDto(exception.category.httpStatus, exception, request.servletPath).toResponseEntity()
+
+    /**
+     * SoaErrorException only carries the eHealth status code in its message, while the reason why the platform
+     * refused the call sits in the response's statusMessage ("This combination of search criteria is not supported.",
+     * "The maxElements paging attribute is too high.", …). Append it so callers get something actionable.
+     */
+    @ExceptionHandler(SoaErrorException::class)
+    fun handleSoaErrorException(request: HttpServletRequest, exception: SoaErrorException) =
+            ExceptionDto(
+                Date(),
+                exception.category.httpStatus.value(),
+                exception.category.httpStatus.reasonPhrase,
+                listOfNotNull(exception.message, statusMessageOf(exception)).joinToString(" - "),
+                request.servletPath
+            ).toResponseEntity()
 
     @ExceptionHandler(MissingKeystoreException::class, MissingTokenException::class, UnauthorizedException::class)
     fun handleUnauthorizedException(request: HttpServletRequest, exception: Exception) =
@@ -41,6 +59,14 @@ class ExceptionHandlers {
     fun handleException(request: HttpServletRequest, exception: Exception) =
             ExceptionDto(HttpStatus.INTERNAL_SERVER_ERROR, exception, request.servletPath).toResponseEntity()
                 .also { log.error("Unhandled exception on ${request.servletPath}", exception) }
+
+    private fun statusMessageOf(exception: SoaErrorException): String? = try {
+        (exception.responseTypeV2 as? StatusResponseType)?.status?.statusMessage
+            ?: exception.responseType?.status?.messages?.firstOrNull()?.value
+            ?: exception.errorType?.messages?.firstOrNull()?.value
+    } catch (e: Exception) {
+        null
+    }
 
     companion object {
         private val log = LoggerFactory.getLogger(ExceptionHandlers::class.java)


### PR DESCRIPTION
## Surface what actually failed on eHealth errors

Two small fixes in `ExceptionHandlers.kt`, both from debugging live calls against acceptance.

**`fix(web): log unhandled exceptions instead of swallowing them`** — the catch-all `Exception` handler built
a 500 response without logging anything, so an unexpected failure left no trace at all in the logs. It now
logs the exception with the servlet path before returning the same response.

**`fix(web): surface the eHealth status message on SOA errors`** — `SoaErrorException` was falling through to
a generic handler, and its message only carries the eHealth status *code*. The reason the platform refused the
call sits in the response's `statusMessage`: `This combination of search criteria is not supported.`,
`The maxElements paging attribute is too high.`, and so on. Without it a caller gets a code and no way to know
what to change.

A dedicated handler now appends that message. It reads it from whichever shape the exception carries
(`responseTypeV2` as `StatusResponseType`, then `responseType.status.messages`, then `errorType.messages`) and
falls back to the bare message if none is present, so no existing behaviour is lost.
