### PR TITLE
feat(efact): carry the kine agreement number in ET 52 Z 19

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/dto/efact/InvoiceItem.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/dto/efact/InvoiceItem.kt
@@ -34,6 +34,18 @@ class InvoiceItem {
     var insuranceRef: String? = null
     var insuranceRefDate: Long? = null
 
+    /**
+     * Agreement number, written to ET 52 Z 19 (20 positions, INAMI annexe 6.8).
+     *
+     * This is *not* [insuranceRef], which goes to ET 51 Z 42. It is the number an insurer assigned to an agreement
+     * decision and returned through eAgreement; INAMI annexe 26.4 makes it mandatory for physiotherapists since
+     * 01/05/2022, and its absence on e.g. code 567011 is rejected with 521904.
+     *
+     * Structure: XXX (mutuality) + 15 digits unique per insurer + DD (check-digit, modulo 97). Optional: when it is
+     * null the zone is written as twenty zeroes, exactly as before this field existed.
+     */
+    var agreementNumber: String? = null
+
     var units: Int = 0
 
     var reimbursedAmount: Long = 0

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/BelgianInsuranceInvoicingFormatWriter.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/BelgianInsuranceInvoicingFormatWriter.kt
@@ -51,6 +51,11 @@ import java.util.GregorianCalendar
 class BelgianInsuranceInvoicingFormatWriter(private val writer: Writer) {
     private val dtf = DateTimeFormatter.ofPattern("yyyyMMdd")
 
+    companion object {
+        /** Physiotherapist, as written to ET 10 Z 18 from [InvoiceSender.professionCode]. */
+        const val KINE_PROFESSION_CODE = 50
+    }
+
     private fun getInsurabilityParameters(patient: Patient, parameter: InsuranceParameter): String? {
         patient.insurabilities
         if (patient.insurabilities.isNotEmpty()) {
@@ -561,19 +566,75 @@ class BelgianInsuranceInvoicingFormatWriter(private val writer: Writer) {
         return recordNumber+1
     }
 
+    /**
+     * Writes an ET 52. It carries the electronic identity document data *and* ET 52 Z 19, the agreement number that
+     * INAMI annexe 26.4 makes mandatory for physiotherapists. The record is produced as soon as
+     * [InvoiceItem.eidItem] or [InvoiceItem.agreementNumber] is set, and when both are set they end up in the same
+     * record, as annexe 26.4 prescribes.
+     *
+     * For a physiotherapist (ET 10 Z 18 = [KINE_PROFESSION_CODE]) the two are *not* independent. Annexe 26.4 is
+     * titled "Enregistrement de type 52 (facultatif, sauf zone 19)": what makes the record mandatory is indeed
+     * zone 19 alone. But once the record exists, the same table makes "Z 9 Type de saisie document identite -
+     * Obligation de completer" and "Z 10 Type de support document identite - Obligation de completer", **with no
+     * exception clause** - unlike Z 6a/6b and Z 12/13 ("sauf lorsque Z 9 = 4 et Z 3 = 3") or Z 16 ("sauf lorsque
+     * Z 10 = 7, 8 ou 9"). So there is no conformant ET 52 with an empty Z 9 / Z 10, and an agreement number without
+     * an [InvoiceItem.eidItem] is refused rather than written as blanks. Note that satisfying Z 9 / Z 10 does not
+     * require an actual card reading: readType 4 (manual) with a deferred manualEntryReason, or deviceType 7
+     * (vignette), are exactly the escape routes the annexe provides, and [EIDItem] already models them.
+     */
     @Throws(IOException::class)
     fun writeEid(recordNumber: Int,
                  icd: InvoiceItem, patient: Patient, invoiceSender: InvoiceSender): Int {
         val ws = WriterSession(writer, Record52Description)
 
-        if (icd.eidItem == null) { return recordNumber }
+        if (icd.eidItem == null && icd.agreementNumber == null) { return recordNumber }
 
-        val eidItem = icd.eidItem!!
+        require(icd.eidItem != null || invoiceSender.professionCode != KINE_PROFESSION_CODE) {
+            "an ET 52 carrying an agreement number must also carry the identity document capture: INAMI annexe 26.4 " +
+                "makes Z 9 (type de saisie) and Z 10 (type de support) mandatory for physiotherapists with no " +
+                "exception. Set InvoiceItem.eidItem - readType 4 with a deferred manualEntryReason, or deviceType 7, " +
+                "when there was no card reading."
+        }
+
+        val agreementNumber = icd.agreementNumber?.also {
+            // ET 52 Z 19 is declared 20 A but holds only digits; a shorter value would be silently blank padded and
+            // rejected as 521901 ("contenu de la zone non numerique") by the insurer. The check-digit itself is not
+            // verified here: annexe 6.8 names "modulo 97" without giving the operand, and the caller owns the value.
+            // The value never appears in these messages: they surface in the 400 body and in the logs.
+            require(it.length == Record52Description.AGREEMENT_NUMBER_LENGTH) {
+                "agreementNumber (ET 52 Z 19) expected exactly ${Record52Description.AGREEMENT_NUMBER_LENGTH} " +
+                    "digits, got ${it.length} characters"
+            }
+            require(it.all { c -> c in '0'..'9' }) {
+                "agreementNumber (ET 52 Z 19) expected exactly ${Record52Description.AGREEMENT_NUMBER_LENGTH} " +
+                    "digits, got a non digit character"
+            }
+        } ?: Record52Description.EMPTY_AGREEMENT_NUMBER
+
+        val eidItem = icd.eidItem
 
         val nf4 = DecimalFormat("0000")
 
         var noSIS: String? = if (patient.ssin != null) patient.ssin else ""
         noSIS = noSIS!!.replace("[^0-9]".toRegex(), "")
+
+        ws.write("2", recordNumber)
+        ws.write("4", icd.codeNomenclature)
+        ws.write("5", FuzzyValues.getLocalDateTime(icd.dateCode!!)!!.format(dtf))
+        ws.write("7", 0)
+        ws.write("8a", noSIS)
+        ws.write("14", 0)
+        ws.write("15", invoiceSender.nihii.toString().padEnd(11, '0'))
+        ws.write("19", agreementNumber)
+
+        if (eidItem == null) {
+            // Agreement number only, for a sector whose annexe does not impose the eID zones: they keep their
+            // default. Refused above for physiotherapists, and no identity document data is ever fabricated here.
+            ws.write("3", 0)
+            ws.write("17", 0)
+            ws.writeFieldsWithCheckSum()
+            return recordNumber + 1
+        }
 
         val isManualEntry = eidItem.readType == EIDItem.READ_TYPE_MANUAL
         val isDeferredCase = isManualEntry && eidItem.manualEntryReason?.let { it in EIDItem.DEFERRED_REASONS } == true
@@ -606,19 +667,12 @@ class BelgianInsuranceInvoicingFormatWriter(private val writer: Writer) {
             require(EIDItem.isValidReadHour(eidItem.readHour)) { "readHour must be a valid HHMM time (HH:00-23, MM:00-59), got: ${eidItem.readHour}" }
         }
 
-        ws.write("2", recordNumber)
         ws.write("3", manualEntryReasonValue)
-        ws.write("4", icd.codeNomenclature)
-        ws.write("5", FuzzyValues.getLocalDateTime(icd.dateCode!!)!!.format(dtf))
         ws.write("6a", if (isDeferredCase) "00000000" else FuzzyValues.getLocalDateTime(validatedReadDate!!)!!.format(dtf))
-        ws.write("7", 0)
-        ws.write("8a", noSIS)
         ws.write("9", eidItem.readType)
         ws.write("10", eidItem.deviceType)
         ws.write("11", vignetteReason)
         ws.write("12", if (isDeferredCase) "0000" else nf4.format(eidItem.readHour))
-        ws.write("14", 0)
-        ws.write("15", invoiceSender.nihii.toString().padEnd(11, '0'))
         ws.write("16", eidItem.readValue ?: "")
         ws.write("17", eidItem.justificationDocumentNumber)
 

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record52Description.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record52Description.kt
@@ -21,7 +21,13 @@ package org.taktik.freehealth.middleware.format.efact.segments
 import java.util.LinkedHashMap
 
 object Record52Description : RecordOrSegmentDescription() {
-    private val ZONE_DESCRIPTIONS_BY_ZONE = LinkedHashMap<String, ZoneDescription>(19)
+    /** Length of ET 52 Z 19, in positions. The zone holds XXX (mutuality) + 15 digits + DD (check-digit mod 97). */
+    const val AGREEMENT_NUMBER_LENGTH = 20
+
+    /** ET 52 Z 19 when no agreement number applies: entirely filled with zeroes (INAMI annexe 7, point f). */
+    const val EMPTY_AGREEMENT_NUMBER = "00000000000000000000"
+
+    private val ZONE_DESCRIPTIONS_BY_ZONE = LinkedHashMap<String, ZoneDescription>(21)
 
     override val zoneDescriptionsByZone: Map<String, ZoneDescription>
         get() = ZONE_DESCRIPTIONS_BY_ZONE
@@ -45,7 +51,15 @@ object Record52Description : RecordOrSegmentDescription() {
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "15", "Numero INAMI", "nihii", "N", pos, 12)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "16", "Valeur lue document identite electronique", "readValue", "A", pos, 15)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "17", "Numero document justificatif", "justificationDocumentNumber", "N", pos, 25)
-        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "18", "reserve", null, "N", pos, 229)
+        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "18", "Numero unique appareil imagerie medicale", "medicalImagingDeviceNumber", "N", pos, 12)
+        // ET 52 Z 19 (20 A, positions 132-151), INAMI annexe 6.8 EDITION 2021. Mandatory for physiotherapists
+        // since 01/05/2022 (footnote 3 / annexe 26.4 "Enregistrement de type 52 (facultatif, sauf zone 19)").
+        // Annexe 7 point f lists this zone as an exception to the alphanumerical padding rule: when it is not
+        // filled it must be filled with zeroes, which is also what the medical / dental annexes (20.x, 23.x)
+        // prescribe ("toujours 0, ne concerne pas les medecins"). Hence the all-zero default value: it keeps the
+        // record byte for byte identical to what was produced when 120-348 was a single numerical reserve.
+        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "19", "Numero d'accord", "agreementNumber", "A", pos, 20, EMPTY_AGREEMENT_NUMBER)
+        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "20", "reserve", null, "N", pos, 197)
               register(ZONE_DESCRIPTIONS_BY_ZONE, "99", "Chiffres de controle de l'enregistrement", null, "N", pos, 2, null, true)
     }
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/EfactServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/EfactServiceImpl.kt
@@ -174,7 +174,8 @@ class EfactServiceImpl(private val stsService: STSService, private val mapper: M
                         metadata.recordsCount++
                     }
 
-                    if (it.eidItem != null) {
+                    // ET 52 carries the eID reading and ET 52 Z 19, the agreement number; either one calls for the record
+                    if (it.eidItem != null || it.agreementNumber != null) {
                         rn = iv.writeEid(rn, it, invoice.patient!!, batch.sender!!)
                         recordCodes.add(it.codeNomenclature)
                         recordsCountPerOA[0]++

--- a/src/test/kotlin/org/taktik/freehealth/middleware/format/efact/Record52AgreementNumberTest.kt
+++ b/src/test/kotlin/org/taktik/freehealth/middleware/format/efact/Record52AgreementNumberTest.kt
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2018 Taktik SA
+ *
+ * This file is part of iCureBackend.
+ *
+ * iCureBackend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as published by
+ * the Free Software Foundation.
+ *
+ * iCureBackend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with iCureBackend.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.taktik.freehealth.middleware.format.efact
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.taktik.freehealth.middleware.domain.common.Patient
+import org.taktik.freehealth.middleware.dto.efact.EIDItem
+import org.taktik.freehealth.middleware.dto.efact.InvoiceItem
+import org.taktik.freehealth.middleware.dto.efact.InvoiceSender
+import org.taktik.freehealth.middleware.format.efact.segments.Record51Description
+import org.taktik.freehealth.middleware.format.efact.segments.Record52Description
+import java.io.StringWriter
+import java.math.BigInteger
+
+/**
+ * ET 52 Z 19, the agreement number — offline, no eHealth call.
+ *
+ * Normative source: INAMI *instructions de facturation electronique*, annexe 6.8 (EDITION 2021), which places
+ * `19  20 A  132-151  Numero d'accord` in the type 52 record, and annexe 26.4 (kinesitherapeutes, MISE A JOUR
+ * 2021/33, publication 23-06-2026), titled "Enregistrement de type 52 (facultatif, sauf zone 19)", which marks
+ * Z 19 "obligation de completer". The zone detail sheet adds: "le numero d'accord, recu via eAgreement, doit etre
+ * complete", structure XXXYYYYYYYYYYYYYYYDD, and footnote (4) "a partir du 01/05/22, cette zone doit
+ * obligatoirement etre completee par les kinesitherapeutes". Annexe 7 point f lists ET 52 Z 19 among the
+ * alphanumerical zones that must be filled with zeroes when unused.
+ *
+ * The same annexe 26.4 also marks "Z 9 Type de saisie document identite" and "Z 10 Type de support document
+ * identite" as "Obligation de completer" with no exception clause — where Z 6a/6b and Z 12/13 carry "sauf lorsque
+ * Z 9 = 4 et Z 3 = 3" and Z 16 carries "sauf lorsque Z 10 = 7, 8 ou 9". A physiotherapist therefore cannot send
+ * Z 19 without the identity document capture, and the writer refuses that combination.
+ */
+class Record52AgreementNumberTest {
+    private val agreementNumber = "30600000000000000103"
+
+    /** ET 10 Z 18 = 50: physiotherapist. Any other value leaves the sector's own annexe in charge. */
+    private fun sender(professionCode: Int? = BelgianInsuranceInvoicingFormatWriter.KINE_PROFESSION_CODE) =
+        InvoiceSender().apply {
+            nihii = 54123456789L
+            bce = 999999922L
+            ssin = "12345678901"
+            firstName = "Jean"
+            lastName = "Kine"
+            phoneNumber = 32470000000L
+            conventionCode = 0
+            this.professionCode = professionCode
+        }
+
+    private fun patient() = Patient().apply { ssin = "86103130262"; firstName = "Test"; lastName = "Patient" }
+
+    private fun eidItem() = EIDItem(20260729000000L, 1030, "5910212346", 0, 1)
+
+    /** A 567011 session on 29/07/2026 — the nominal accepted scenario of the CIN physiotherapist test manual. */
+    private fun item() = InvoiceItem().apply {
+        codeNomenclature = 567011L
+        dateCode = 20260729L
+        reimbursedAmount = 1000L
+    }
+
+    private fun write(icd: InvoiceItem, sender: InvoiceSender = sender()): String {
+        val sw = StringWriter()
+        val recordNumber = BelgianInsuranceInvoicingFormatWriter(sw).writeEid(3, icd, patient(), sender)
+        return sw.toString().also { assertThat(recordNumber).isEqualTo(if (it.isEmpty()) 3 else 4) }
+    }
+
+    /** Independent re-implementation of the eFact check digit, so the assertion does not lean on the writer. */
+    private fun expectedCheckDigits(recordWithoutCheckDigits: String): String {
+        var sum = BigInteger.ZERO
+        for (c in recordWithoutCheckDigits) {
+            val v = when (c) {
+                in '0'..'9' -> (c - '0').toLong()
+                ' ' -> 10L
+                in 'A'..'Z' -> (c - 'A' + 11).toLong()
+                in 'a'..'z' -> (c - 'a' + 11).toLong()
+                else -> 37L
+            }
+            sum = sum.add(BigInteger.valueOf(v))
+        }
+        val modulo = sum.mod(BigInteger.valueOf(97)).toInt()
+        return String.format("%02d", if (modulo == 0) 97 else modulo)
+    }
+
+    private fun assertWellFormed(record: String) {
+        assertThat(record).hasSize(350)
+        assertThat(record.take(2)).isEqualTo("52")
+        assertThat(record.takeLast(2)).isEqualTo(expectedCheckDigits(record.dropLast(2)))
+    }
+
+    private fun zone19(record: String): String {
+        val zd = Record52Description.zoneDescriptionsByZone["19"]!!
+        assertThat(zd.position).isEqualTo(132)
+        assertThat(zd.length).isEqualTo(20)
+        return record.substring(zd.position - 1, zd.position - 1 + zd.length)
+    }
+
+    // 1 + 3 + 4 — a physiotherapy 567011 with an agreement number produces a 350 character record 52 with valid
+    // check digits. Annexe 26.4 requires the identity document capture in the very same record, hence the eidItem.
+    @Test
+    fun physiotherapyItemWithAgreementNumberProducesRecord52() {
+        val record = write(item().apply {
+            eidItem = eidItem()
+            agreementNumber = this@Record52AgreementNumberTest.agreementNumber
+        })
+
+        assertWellFormed(record)
+        assertThat(record.substring(9, 16)).isEqualTo("0567011")   // Z 4, = ET 50 Z 4
+        assertThat(record.substring(16, 24)).isEqualTo("20260729") // Z 5, = ET 50 Z 5
+    }
+
+    // 2 — ET 52 Z 19 holds exactly the number supplied, at positions 132-151
+    @Test
+    fun zone19HoldsExactlyTheSuppliedNumber() {
+        val record = write(item().apply {
+            eidItem = eidItem()
+            agreementNumber = this@Record52AgreementNumberTest.agreementNumber
+        })
+
+        assertThat(zone19(record)).isEqualTo(agreementNumber)
+    }
+
+    // annexe 26.4 makes Z 9 and Z 10 unconditional, so a physiotherapist cannot send Z 19 without an eID capture
+    @Test
+    fun agreementNumberWithoutEidIsRefusedForAPhysiotherapist() {
+        assertThatThrownBy { write(item().apply { agreementNumber = this@Record52AgreementNumberTest.agreementNumber }) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("annexe 26.4")
+            .hasMessageContaining("Z 9")
+            .hasMessageContaining("Z 10")
+    }
+
+    // ... and no other sector is affected: the refusal is keyed on ET 10 Z 18 alone
+    @Test
+    fun agreementNumberWithoutEidStillWritesForOtherProfessions() {
+        listOf(null, 30).forEach { professionCode ->
+            val record = write(
+                item().apply { agreementNumber = this@Record52AgreementNumberTest.agreementNumber },
+                sender(professionCode))
+
+            assertWellFormed(record)
+            assertThat(zone19(record)).isEqualTo(agreementNumber)
+        }
+    }
+
+    // 5 — with no agreement number and no eID, nothing at all is written, as before
+    @Test
+    fun withoutAgreementNumberAndWithoutEidNothingIsWritten() {
+        assertThat(write(item())).isEmpty()
+    }
+
+    // 5 + 7 — an eID item alone still produces the exact record it produced before ET 52 Z 19 existed
+    @Test
+    fun eidAloneIsByteForByteUnchanged() {
+        val record = write(item().apply { eidItem = eidItem() })
+
+        assertWellFormed(record)
+        assertThat(record).isEqualTo(
+            "52" + "000003" + "0" + "0567011" + "20260729" + "20260729" + "000" + "0086103130262" +
+                "1" + "1" + "0" + "1030" + "000000000000" + "054123456789" + "5910212346     " +
+                "0000000000000000000000001" + "0".repeat(229) + "68"
+        )
+        // the zone that did not exist before is where the reserve zeroes used to be
+        assertThat(zone19(record)).isEqualTo(Record52Description.EMPTY_AGREEMENT_NUMBER)
+    }
+
+    // 8 — eID data and agreement number coexist in a single conformant record 52
+    @Test
+    fun eidAndAgreementNumberCoexistInOneRecord() {
+        val record = write(item().apply {
+            eidItem = eidItem()
+            agreementNumber = this@Record52AgreementNumberTest.agreementNumber
+        })
+
+        assertWellFormed(record)
+        assertThat(zone19(record)).isEqualTo(agreementNumber)
+        // every eID zone is untouched: only positions 132-151 differ from the eID-only record
+        val eidOnly = write(item().apply { eidItem = eidItem() })
+        assertThat(record.take(131)).isEqualTo(eidOnly.take(131))
+        assertThat(record.substring(151, 348)).isEqualTo(eidOnly.substring(151, 348))
+    }
+
+    // 6 — insuranceRef keeps feeding ET 51 Z 42 and never reaches ET 52 Z 19
+    @Test
+    fun insuranceRefStillGoesToRecord51Zone42() {
+        val sw = StringWriter()
+        val icd = item().apply {
+            insuranceRef = "1234567890"
+            insuranceRefDate = 20260729L
+            doctorIdentificationNumber = "54123456789"
+        }
+        BelgianInsuranceInvoicingFormatWriter(sw)
+            .writeInvolvementRecordContent(3, sender(), 2026, 7, patient(), false, icd)
+        val record = sw.toString()
+
+        assertThat(record).hasSize(350)
+        assertThat(record.take(2)).isEqualTo("51")
+        val zd = Record51Description.zoneDescriptionsByZone["42"]!!
+        assertThat(record.substring(zd.position - 1, zd.position - 1 + 10)).isEqualTo("1234567890")
+
+        // and the same item, written as a record 52, leaves Z 19 empty
+        assertThat(zone19(write(icd.apply { eidItem = eidItem() }))).isEqualTo(Record52Description.EMPTY_AGREEMENT_NUMBER)
+    }
+
+    /**
+     * Nothing at all reaches the Writer when a validation fails, so a refused record cannot corrupt the flat file.
+     * This is the invariant PR #100 was reviewed against ("move the requires before the first ws.write"): the
+     * agreement number zones are now computed before the eID requires, which is safe only because WriterSession
+     * buffers every write into a map and emits on writeFieldsWithCheckSum() alone. Asserted rather than assumed.
+     */
+    @Test
+    fun aRefusedRecordEmitsNothingAtAll() {
+        val refused = listOf<InvoiceItem.() -> Unit>(
+            { agreementNumber = "306" },                                           // malformed Z 19
+            { agreementNumber = this@Record52AgreementNumberTest.agreementNumber }, // Z 19 without eID, kine
+            { eidItem = eidItem().apply { readType = "Z" } },                       // invalid Z 9
+            { eidItem = eidItem().apply { deviceType = "Z" } }                      // invalid Z 10
+        )
+
+        refused.forEach { spoil ->
+            val sw = StringWriter()
+            val writer = BelgianInsuranceInvoicingFormatWriter(sw)
+            val icd = item().apply(spoil)
+
+            assertThatThrownBy { writer.writeEid(3, icd, patient(), sender()) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(sw.toString()).isEmpty()
+        }
+    }
+
+    // the layout stays a valid 350 position paving
+    @Test
+    fun record52LayoutPavesExactly350Positions() {
+        val zones = Record52Description.zoneDescriptions
+        var expected = 1
+        zones.forEach {
+            assertThat(it.position).`as`("zone ${it.zone} starts at ${it.position}").isEqualTo(expected)
+            expected += it.length
+        }
+        assertThat(expected - 1).isEqualTo(350)
+    }
+
+    @Test
+    fun malformedAgreementNumbersAreRefusedRatherThanSilentlyPadded() {
+        listOf("306", "3060000000000000010A", "30600000000000000103 ").forEach { malformed ->
+            assertThatThrownBy { write(item().apply { eidItem = eidItem(); agreementNumber = malformed }) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("ET 52 Z 19")
+                .hasMessageContaining("expected exactly 20 digits")
+        }
+    }
+
+    // the number reaches a 400 response body and the logs through the exception message: it must not be in there
+    @Test
+    fun theRefusalMessageNeverEchoesTheAgreementNumber() {
+        listOf("306", "3060000000000000010A", "30600000000000000103 ", agreementNumber.dropLast(1)).forEach { value ->
+            assertThatThrownBy { write(item().apply { eidItem = eidItem(); agreementNumber = value }) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .matches({ it.message?.contains(value.trim()) == false }, "message must not echo the value")
+        }
+    }
+}

--- a/src/test/kotlin/org/taktik/freehealth/middleware/web/controllers/EfactFlatcoreOfflineTest.kt
+++ b/src/test/kotlin/org/taktik/freehealth/middleware/web/controllers/EfactFlatcoreOfflineTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2018 Taktik SA
+ *
+ * This file is part of iCureBackend.
+ *
+ * iCureBackend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as published by
+ * the Free Software Foundation.
+ *
+ * iCureBackend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with iCureBackend.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.taktik.freehealth.middleware.web.controllers
+
+import com.google.gson.JsonParser
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.junit4.SpringRunner
+import org.taktik.freehealth.middleware.MyTestsConfiguration
+
+/**
+ * `/efact/flatcore` renders the flat file locally: no keystore, no token, no MyCareNet call. Used here to prove that
+ * a physiotherapy invoice carrying an agreement number produces an ET 52 with the number in zone 19 (positions
+ * 132-151), per INAMI annexe 6.8 / annexe 26.4.
+ */
+@RunWith(SpringRunner::class)
+@Import(MyTestsConfiguration::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class EfactFlatcoreOfflineTest {
+    @LocalServerPort
+    private val port: Int = 0
+
+    @Autowired
+    private val restTemplate: TestRestTemplate? = null
+
+    private val agreementNumber = "30600000000000000103"
+
+    /** readType 1 / deviceType 1: an eID chip reading. ET 52 Z 9 and Z 10, which annexe 26.4 always requires. */
+    private val eidItem = """
+        "eidItem": { "readDate": 20260729000000, "readHour": 1030, "readValue": "5910212346",
+                     "readType": "1", "deviceType": "1", "vignetteReason": 0, "justificationDocumentNumber": 1 }
+    """.trimIndent()
+
+    private fun batch(itemExtras: String) = """
+        {
+          "invoicingYear": 2026, "invoicingMonth": 7,
+          "batchRef": "TESTBATCH0001", "uniqueSendNumber": 1, "numericalRef": 1,
+          "ioFederationCode": "300", "invoiceContent": 40,
+          "sender": {
+            "nihii": 54123456789, "bce": 999999922, "ssin": "12345678901",
+            "firstName": "Jean", "lastName": "Kine", "phoneNumber": 32470000000, "conventionCode": 0,
+            "professionCode": 50
+          },
+          "invoices": [{
+            "ioCode": "306", "invoiceNumber": 1, "invoiceRef": "TESTINV0001", "reason": "Other",
+            "patient": { "ssin": "86103130262", "firstName": "Test", "lastName": "Patient" },
+            "items": [{
+              "codeNomenclature": 567011, "dateCode": 20260729, "reimbursedAmount": 1000,
+              "doctorIdentificationNumber": "54123456789"$itemExtras
+            }]
+          }]
+        }
+    """.trimIndent()
+
+    private fun post(body: String) = restTemplate!!.postForEntity(
+        "http://localhost:$port/efact/flatcore",
+        HttpEntity(body, HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON }),
+        String::class.java)
+
+    private fun flatcore(body: String): List<String> {
+        val response = post(body)
+        assertThat(response.statusCode.value()).isEqualTo(200)
+        val flatFile = JsonParser().parse(response.body).asJsonObject.get("flatFile").asString
+        return flatFile.chunked(350).also { records -> assertThat(records).allMatch { it.length == 350 } }
+    }
+
+    @Test
+    fun flatcoreNeedsNoAuthenticationAndEmitsNoRecord52WithoutAgreementNumber() {
+        assertThat(flatcore(batch("")).map { it.take(2) }).containsExactly("10", "20", "50", "80", "90")
+    }
+
+    @Test
+    fun anAgreementNumberEmitsARecord52CarryingItInZone19() {
+        val records = flatcore(batch(""", "agreementNumber": "$agreementNumber", $eidItem"""))
+
+        assertThat(records.map { it.take(2) }).containsExactly("10", "20", "50", "52", "80", "90")
+        val record52 = records.single { it.startsWith("52") }
+        assertThat(record52.substring(131, 151)).isEqualTo(agreementNumber)
+    }
+
+    /**
+     * Annexe 26.4 makes ET 52 Z 9 and Z 10 mandatory with no exception clause, so a physiotherapy batch cannot carry
+     * the agreement number alone. The 400 body must name the rule and must not echo the number back.
+     */
+    @Test
+    fun anAgreementNumberWithoutEidIsRefusedWithoutEchoingTheNumber() {
+        val response = post(batch(""", "agreementNumber": "$agreementNumber""""))
+
+        assertThat(response.statusCode.value()).isEqualTo(400)
+        assertThat(response.body).contains("annexe 26.4").doesNotContain(agreementNumber)
+    }
+
+    @Test
+    fun aMalformedAgreementNumberIsRefusedWithoutEchoingTheNumber() {
+        val response = post(batch(""", "agreementNumber": "306", $eidItem"""))
+
+        assertThat(response.statusCode.value()).isEqualTo(400)
+        assertThat(response.body).contains("expected exactly 20 digits")
+    }
+
+    @Test
+    fun insuranceRefStillEmitsRecord51AndNotRecord52() {
+        val records = flatcore(batch(""", "insuranceRef": "1234567890", "insuranceRefDate": 20260729"""))
+
+        assertThat(records.map { it.take(2) }).containsExactly("10", "20", "50", "51", "80", "90")
+    }
+}


### PR DESCRIPTION
## What

`ET 52 Z 19` — the agreement number — could not be produced at all.
`Record52Description` declared positions **120-348 as a single 229 position numerical
reserve**, which covers zones 18, 19 and 20-98 at once, so the zone was unreachable and
always written as zeroes. `InvoiceItem.insuranceRef` is not a substitute: it feeds
`ET 51 Z 42` through `writeInvolvementRecordContent`.

For a physiotherapist that means every `567011` is rejected **521904** *"Numéro d'accord
fait défaut alors qu'il est indispensable"*, which is scenario 1 of the CIN physiotherapy
invoicing test manual.

This is the physiotherapy counterpart of #100: the same ET 52, the sector next door.

## Normative source

INAMI *instructions de facturation électronique*:

| Reference | Says |
|---|---|
| **annexe 6.8**, EDITION 2021 | `(3) 19 · 20 A · 132-151 · Numéro d'accord` |
| zone sheet **ET 52 Z 19** | `20 A - 132`; *"le numéro d'accord, reçu via eAgreement, doit être complété"*; structure `XXXYYYYYYYYYYYYYYYDD`; note (4) *"à partir du 01/05/22, cette zone doit obligatoirement être complétée par les kinésithérapeutes"* |
| **annexe 26.4** (kiné) | *"Enregistrement de type 52 (facultatif, sauf zone 19)"* · `19 Numéro d'accord — Obligation de compléter` |
| **annexe 23.4** (dentiste) | `19 Numéro d'accord — Toujours 0, ne concerne pas les dentistes` |
| **annexe 7, point a** | *"les zones **9, 10, 16, 19** de l'enregistrement de type 52"* are the alphanumerical ones — confirms the `A` type |
| **annexe 7, point f** | ET 52 Z 19 unfilled must be *"complètement remplie de zéro"* |

## What changes

- `Record52Description`: the 229 position reserve is split per annexe 6.8 into
  `18` (12 N, 120-131), **`19` (20 A, 132-151)** and `20-98` (197 N, 152-348).
- `InvoiceItem.agreementNumber: String?` — new, optional, JSON backward compatible.
- `writeEid` writes Z 19 and now produces the record when *either* `eidItem` or
  `agreementNumber` is set; both end up in a single ET 52, as annexe 26.4 prescribes.

**Nothing changes for existing senders.** Zone 19 defaults to twenty zeroes, which is both
what annexe 7 point f requires and byte for byte what the numerical reserve produced — so
existing records 52 and their check digits are untouched, dentists included (annexe 23.4
wants exactly those zeroes). A golden test asserts that equality character by character.

## The physiotherapy guard

Annexe 26.4 marks `Z 9` (type de saisie) and `Z 10` (type de support) *"Obligation de
compléter"* **with no exception clause** — unlike `Z 6a/6b` and `Z 12/13` (*"sauf lorsque
Z 9 = 4 et Z 3 = 3"*) or `Z 16` (*"sauf lorsque Z 10 = 7, 8 ou 9"*). There is therefore no
conformant ET 52 with an empty Z 9 / Z 10, so `agreementNumber` without an `eidItem` is
**refused** for a physiotherapist (`InvoiceSender.professionCode == 50`, ET 10 Z 18) rather
than written as blanks. No identity document data is ever fabricated; satisfying Z 9 / Z 10
without a card reading is what `readType = 4` + a deferred `manualEntryReason`, or
`deviceType = 7`, are for — `EIDItem` already models both. Any other sector keeps the
previous behaviour, and that is covered by a test.

## Two notes for the reviewer

- **The agreement number never appears in an exception message.** Unlike the enum values
  validated in #100, it is a business identifier from the insurer and it would surface in
  the 400 response body and in the logs. The messages say `expected exactly 20 digits`
  plus, at most, the received length. Two tests assert the absence, one of them on the real
  HTTP 400 body.
- **The zones common to both cases are computed before the eID `require`s.** #100 was
  reviewed against *"move the requires before the first ws.write"*; that invariant still
  holds, because `WriterSession.write()` only fills a map and nothing reaches the `Writer`
  before `writeFieldsWithCheckSum()`. `aRefusedRecordEmitsNothingAtAll` asserts it on four
  distinct refusals rather than leaving it to be assumed.

The check digit is deliberately **not** verified: annexe 6.8 names *"modulo 97"* without the
operand or the direction, and a false rejection in production would be worse than a 521902.
Only the *"exactly 20 digits"* rule, which maps to the unambiguous 521901, is enforced.

## Tests

17 offline tests, no eHealth call, no keystore, no `test.properties`:

- `Record52AgreementNumberTest` (12) — the writer, including the byte for byte golden
  record, the 350 position paving, the check digits recomputed independently, and the
  `insuranceRef` → ET 51 Z 42 control.
- `EfactFlatcoreOfflineTest` (5) — `POST /efact/flatcore` end to end with no auth header:
  `10, 20, 50, 52, 80, 90` with the number at positions 132-151, and the two refusals.

```
./gradlew test --tests "*Record52AgreementNumberTest" --tests "*EfactFlatcoreOfflineTest"
```
